### PR TITLE
feat: add star background and decorative clouds

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,11 @@
 import { Routes, Route } from 'react-router-dom';
 import Home from './pages/home';
+import StarBackground from './components/StarBackground';
 
 export default function App() {
   return (
-    <div id="page" className="min-h-screen w-full overflow-x-clip">
+    <div id="page" className="min-h-screen w-full overflow-x-clip relative">
+      <StarBackground />
       <Routes>
         <Route path="/" element={<Home />} />
       </Routes>

--- a/src/components/FloatingRocket.jsx
+++ b/src/components/FloatingRocket.jsx
@@ -1,4 +1,4 @@
-import { motion, useAnimation, useReducedMotion } from "framer-motion";
+import { motion as Motion, useAnimation, useReducedMotion } from "framer-motion";
 import { useEffect, useMemo } from "react";
 import rocket from "../assets/cohete-nuevo.png";
 import useIsMobile from "../hooks/useIsMobile";
@@ -56,7 +56,7 @@ export default function FloatingRocket() {
   }, [controls, target, prefersReduced]);
 
   return (
-    <motion.div
+    <Motion.div
       // Arranca fuera de pantalla para “llegar”
       initial={{ x: "-40vw", y: -10, opacity: 0, rotate: 0 }}
       animate={controls}
@@ -71,6 +71,6 @@ export default function FloatingRocket() {
         className="select-none opacity-100 w-28 md:w-60"
         draggable={false}
       />
-    </motion.div>
+    </Motion.div>
   );
 }

--- a/src/components/Formularioreseva.jsx
+++ b/src/components/Formularioreseva.jsx
@@ -1,5 +1,6 @@
 // src/components/FormularioReserva.jsx
 import { useSearchParams } from 'react-router-dom';
+import TitleWithClouds from './TitleWithClouds';
 
 export default function FormularioReserva() {
   const [searchParams] = useSearchParams();
@@ -7,7 +8,7 @@ export default function FormularioReserva() {
 
   return (
     <section id="reserva" className="min-h-screen bg-[#C5E0D8] md:bg-[#F6E9DF] flex flex-col items-center justify-center px-4">
-      <h1 className="text-4xl volkhov-bold mb-8">RESERVA TU HORA</h1>
+      <div className="mb-8"><TitleWithClouds as="h1" className="text-4xl volkhov-bold text-center">RESERVA TU HORA</TitleWithClouds></div>
       <form className="bg-white p-8 rounded-xl shadow-md w-full max-w-md space-y-4">
         <div className="grid-col">
           <label className="text-sm font-semibold mb-1">Especie</label>

--- a/src/components/LandingRocket.jsx
+++ b/src/components/LandingRocket.jsx
@@ -1,0 +1,23 @@
+import { motion as Motion, useReducedMotion } from "framer-motion";
+import rocket from "../assets/cohete-nuevo.png";
+import useIsMobile from "../hooks/useIsMobile";
+
+export default function LandingRocket() {
+  const isMobile = useIsMobile();
+  const prefersReduced = useReducedMotion();
+
+  if (isMobile) return null;
+
+  return (
+    <div className="relative h-64 overflow-visible">
+      <Motion.img
+        src={rocket}
+        alt="Cohete aterrizando"
+        className="absolute left-1/2 -translate-x-1/2 w-40"
+        initial={prefersReduced ? { y: 0, rotate: 180, opacity: 1 } : { y: -200, rotate: 180, opacity: 0 }}
+        whileInView={{ y: 0, rotate: 180, opacity: 1 }}
+        transition={{ duration: 1.5, ease: [0.23, 1, 0.32, 1] }}
+      />
+    </div>
+  );
+}

--- a/src/components/Servicios.jsx
+++ b/src/components/Servicios.jsx
@@ -1,6 +1,7 @@
 // Servicios.jsx
 import { useRef } from "react";
 import ServicioCard from "./ServicioCard";
+import TitleWithClouds from "./TitleWithClouds";
 import { FaStethoscope, FaSyringe, FaIdBadge, FaPassport, FaFlask, FaDog, FaAmbulance } from "react-icons/fa";
 
 const servicios = [
@@ -17,9 +18,16 @@ export default function Servicios() {
   const trackRef = useRef(null);
   const scroll = (dir)=> trackRef.current?.scrollBy({ left: dir * trackRef.current.clientWidth * 0.9, behavior: "smooth" });
 
-  return (/* bg-[#C5E0D8]/70 */
+  return (
     <section id="servicios" className="md:bg-[#F6E9DF] bg-[#C5E0D8]/70 min-h-screen flex flex-col justify-start pt-[clamp(1rem,6vh,3rem)] pb-12">
-      <h2 className="text-center text-3xl lg:text-5xl volkhov-bold text-neutralDark/85 mt-[min(4vw)] mb-[min(12vw)]  md:mt-[min(0.5vw)] md:mb-[min(2.1vw)]">Nuestros Servicios</h2>
+      <div className="text-center mt-[min(4vw)] mb-[min(12vw)] md:mt-[min(0.5vw)] md:mb-[min(2.1vw)]">
+        <TitleWithClouds
+          as="h2"
+          className="text-3xl lg:text-5xl volkhov-bold text-neutralDark/85"
+        >
+          Nuestros Servicios
+        </TitleWithClouds>
+      </div>
 
       {/* MOBILE */}
       <div className="relative md:hidden">
@@ -32,9 +40,7 @@ export default function Servicios() {
             <ServicioCard
               key={s.titulo}
               {...s}
-              // Más grande: ocupa ~94vw con tope, alto lo controla la card (h-[360px])
               className="shrink-0 snap-center w-[min(94vw,560px)] mx-auto"
-              // Si quieres “peek”: cambia a w-[min(88vw,520px)]
             />
           ))}
         </div>
@@ -48,28 +54,28 @@ export default function Servicios() {
 
       {/* DESKTOP */}
       <div className="hidden md:block px-4">
-  {/* Fila superior: 4 columnas fijas */}
-  <div
-    className="grid gap-8 mx-auto justify-center"
-    style={{ gridTemplateColumns: "repeat(4, 300px)" }} // ajusta 300px al ancho de tu card
-  >
-    {servicios.slice(0, 4).map((s) => (
-      <ServicioCard key={s.titulo} {...s} />
-    ))}
-  </div>
+        {/* Fila superior: 4 columnas fijas */}
+        <div
+          className="grid gap-8 mx-auto justify-center"
+          style={{ gridTemplateColumns: "repeat(4, 300px)" }} // ajusta 300px al ancho de tu card
+        >
+          {servicios.slice(0, 4).map((s) => (
+            <ServicioCard key={s.titulo} {...s} />
+          ))}
+        </div>
 
-  {/* Fila inferior: bloque centrado con 3 columnas */}
-  <div className="mt-8 flex justify-center">
-    <div
-      className="grid gap-8"
-      style={{ gridTemplateColumns: "repeat(3, 300px)" }} // mismo ancho que arriba
-    >
-      {servicios.slice(4).map((s) => (
-        <ServicioCard key={s.titulo} {...s} />
-      ))}
-    </div>
-  </div>
-</div>
+        {/* Fila inferior: bloque centrado con 3 columnas */}
+        <div className="mt-8 flex justify-center">
+          <div
+            className="grid gap-8"
+            style={{ gridTemplateColumns: "repeat(3, 300px)" }} // mismo ancho que arriba
+          >
+            {servicios.slice(4).map((s) => (
+              <ServicioCard key={s.titulo} {...s} />
+            ))}
+          </div>
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/components/SobreNosotros.jsx
+++ b/src/components/SobreNosotros.jsx
@@ -1,4 +1,5 @@
 import about_img from '../assets/JetVetIlustracion02_WIP2_500px.png';
+import TitleWithClouds from './TitleWithClouds';
 
 export default function SobreNosotros() {
   return (
@@ -20,7 +21,7 @@ export default function SobreNosotros() {
 
   {/* Texto: en mobile arriba (order-1), en desktop a la derecha (lg:order-2) */}
   <div className="order-1 lg:order-2 max-w-3xl mx-auto lg:mx-0 text-center lg:text-left">
-    <h2 className="text-3xl lg:text-5xl volkhov-bold mb-6">Sobre Nosotros</h2>
+    <TitleWithClouds as="h2" className="text-3xl lg:text-5xl volkhov-bold mb-6">Sobre Nosotros</TitleWithClouds>
     <p className="text-lg lg:text-xl volkhov-regular">
       Jet Vets Quisque tincidunt diam eget tempus hendrerit. Suspendisse nibh urna,
       consectetur quis lectus ut, pharetra volutpat nulla. Integer ornare justo mauris,

--- a/src/components/StarBackground.jsx
+++ b/src/components/StarBackground.jsx
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+
+export default function StarBackground({ count = 40 }) {
+  const stars = useMemo(() => {
+    return Array.from({ length: count }).map(() => {
+      const size = Math.random() * 2 + 1; // 1-3px
+      return {
+        width: `${size}px`,
+        height: `${size}px`,
+        top: `${Math.random() * 100}%`,
+        left: `${Math.random() * 100}%`,
+        animationDelay: `${Math.random() * 3}s`
+      };
+    });
+  }, [count]);
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-40 mix-blend-screen">
+      {stars.map((style, i) => (
+        <span
+          key={i}
+          className="absolute bg-white rounded-full opacity-70 animate-twinkle"
+          style={style}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/TitleWithClouds.jsx
+++ b/src/components/TitleWithClouds.jsx
@@ -1,0 +1,23 @@
+import cloud1 from "../assets/cloud.webp";
+import cloud2 from "../assets/cloud_2.webp";
+
+export default function TitleWithClouds({ children, as = "h2", className = "" }) {
+  const Tag = as;
+  return (
+    <div className="relative inline-block">
+      <Tag className={`relative z-10 ${className}`}>{children}</Tag>
+      <img
+        src={cloud1}
+        alt=""
+        aria-hidden="true"
+        className="hidden sm:block absolute -top-6 -left-20 w-28 pointer-events-none select-none"
+      />
+      <img
+        src={cloud2}
+        alt=""
+        aria-hidden="true"
+        className="hidden sm:block absolute -bottom-6 -right-20 w-28 pointer-events-none select-none"
+      />
+    </div>
+  );
+}

--- a/src/components/hero.jsx
+++ b/src/components/hero.jsx
@@ -7,10 +7,10 @@ export default function Hero() {
     <section className="relative isolate bg-[#F6E9DF] w-full min-h-screen flex items-center overflow-x-clip">
       {/* Cohete animado */}
       <FloatingRocket />
-      <div className="w-full max-w-[1600px] mx-auto px-6 lg:px-20 grid grid-cols-1 lg:grid-cols-2 gap-12 py-12">
+      <div className="w-full max-w-[1600px] mx-auto px-6 lg:px-20 grid grid-cols-1 md:grid-cols-2 gap-12 py-12">
         
         {/* Texto */}
-        <div className="flex flex-col justify-center items-center lg:items-end text-center lg:text-right gap-6 lg:gap-10">
+        <div className="flex flex-col justify-center items-center md:items-end text-center md:text-right gap-6 md:gap-10">
           <h1 className="volkhov-bold text-[35px] sm:text-[45px] lg:text-[60px] text-neutralDark leading-[1.2] tracking-tight">
             Jet Vets <br />
             <span className="text-primary">un servicio de otra galaxia </span><br />
@@ -22,11 +22,11 @@ export default function Hero() {
         </div>
 
         {/* Imagen */}
-        <div className="flex justify-center lg:justify-end items-center">
+        <div className="flex justify-center md:justify-end items-center">
           <img
             src={mascotas}
             alt="Astronauta Jet Vets"
-            className="w-[330px] md:w-[380px] lg:w-[500px] lg:translate-y-[-30px] lg:translate-x-[-60px]"
+            className="w-[330px] md:w-[380px] lg:w-[500px] md:translate-y-[-30px] md:translate-x-[-60px]"
           />
         </div>
         

--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,15 @@ button:focus-visible {
   .animate-float {
     animation: float 3s ease-in-out infinite;
   }
+
+  @keyframes twinkle {
+    0%,100% { opacity: 0.2; }
+    50% { opacity: 1; }
+  }
+
+  .animate-twinkle {
+    animation: twinkle 2s infinite ease-in-out;
+  }
 }
 
 /* Seguridad de layout */

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -4,6 +4,7 @@ import Footer from '../components/footer';
 import SobreNosotros from '../components/SobreNosotros';
 import Servicios from '../components/Servicios';
 import FormularioReserva from '../components/Formularioreseva';
+import LandingRocket from '../components/LandingRocket';
 
 export default function Home() {
   return (
@@ -13,6 +14,7 @@ export default function Home() {
       <Servicios />
       <SobreNosotros />
       <FormularioReserva />
+      <LandingRocket />
       <Footer />
     </>
   );


### PR DESCRIPTION
## Summary
- add animated star background overlay
- decorate section titles with clouds
- show landing rocket on desktop only and improve tablet layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ffde141d4832f9a164b76a34c1600