### PR TITLE
Add new services and email booking integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## EmailJS configuration
+
+Create a `.env` file in the project root with the following variables to allow the reservation form to send emails using [EmailJS](https://www.emailjs.com/):
+
+```
+VITE_EMAILJS_SERVICE_ID=your_service_id
+VITE_EMAILJS_TEMPLATE_ID=your_template_id
+VITE_EMAILJS_PUBLIC_KEY=your_public_key
+```
+
+These values are provided by EmailJS. The form will send the submitted data to the configured service.

--- a/src/components/Formularioreseva.jsx
+++ b/src/components/Formularioreseva.jsx
@@ -1,10 +1,37 @@
 // src/components/FormularioReserva.jsx
 import { useSearchParams } from 'react-router-dom';
+import { useState } from 'react';
 import TitleWithClouds from './TitleWithClouds';
 
 export default function FormularioReserva() {
   const [searchParams] = useSearchParams();
   const asunto = searchParams.get('asunto') || '';
+  const [status, setStatus] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const formData = new FormData(e.target);
+    try {
+      const res = await fetch('https://api.emailjs.com/api/v1.0/email/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          service_id: import.meta.env.VITE_EMAILJS_SERVICE_ID,
+          template_id: import.meta.env.VITE_EMAILJS_TEMPLATE_ID,
+          user_id: import.meta.env.VITE_EMAILJS_PUBLIC_KEY,
+          template_params: Object.fromEntries(formData.entries()),
+        }),
+      });
+      if (res.ok) {
+        setStatus('success');
+        e.target.reset();
+      } else {
+        setStatus('error');
+      }
+    } catch {
+      setStatus('error');
+    }
+  };
 
   return (
     <section
@@ -17,7 +44,7 @@ export default function FormularioReserva() {
         </TitleWithClouds>
       </div>
 
-      <form className="bg-white dark:bg-neutral-800 dark:text-white p-8 rounded-xl shadow-md w-full max-w-md space-y-4">
+      <form onSubmit={handleSubmit} className="bg-white dark:bg-neutral-800 dark:text-white p-8 rounded-xl shadow-md w-full max-w-md space-y-4">
 
         {/* Fila 1: Especie / Edad */}
         <div className="grid grid-cols-2 gap-4">
@@ -97,6 +124,12 @@ export default function FormularioReserva() {
           Reservar Hora
         </button>
       </form>
+      {status === 'success' && (
+        <p className="mt-4 text-green-600">Solicitud enviada</p>
+      )}
+      {status === 'error' && (
+        <p className="mt-4 text-red-600">Hubo un problema, inténtalo más tarde</p>
+      )}
     </section>
   );
 }

--- a/src/components/ServicioCard.jsx
+++ b/src/components/ServicioCard.jsx
@@ -1,8 +1,7 @@
-// ServicioCard.jsx
 import { useState } from "react";
 import useIsMobile from "../hooks/useIsMobile";
 
-export default function ServicioCard({ titulo, descripcion, icono, className="" }) {
+export default function ServicioCard({ titulo, icono, className="" }) {
   const [flipped, setFlipped] = useState(false);
   const isMobile = useIsMobile();
   const hover = (v)=>{ if (!isMobile) setFlipped(v); };
@@ -22,10 +21,21 @@ export default function ServicioCard({ titulo, descripcion, icono, className="" 
 
         {/* Reverso */}
         <div className="absolute inset-0 rounded-2xl shadow-[0_12px_28px_rgba(0,0,0,.18)] bg-[#C5E0D8] text-neutralDark [transform:rotateY(180deg)] [backface-visibility:hidden] p-5 flex flex-col items-center justify-center gap-3">
-          <p className="text-sm text-center">{descripcion}</p>
-          <a href={`/reserva?asunto=${encodeURIComponent(titulo)}`}
-             className="bg-[#41658A] text-white px-4 py-2 rounded-lg hover:opacity-90">
+          {icono ? <div className="text-5xl mb-2">{icono}</div> : null}
+          <a
+            href={`/reserva?asunto=${encodeURIComponent(titulo)}`}
+            className="bg-[#41658A] text-white px-4 py-2 rounded-lg hover:opacity-90"
+          >
             Reservar Hora
+          </a>
+          <a
+            href={`https://wa.me/34666666666?text=${encodeURIComponent(`Hola, estoy interesado en ${titulo}`)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-[#25D366] text-white px-4 py-2 rounded-lg hover:opacity-90 flex items-center gap-2"
+          >
+            <img src="src/assets/icons8-whatsapp.svg" alt="WhatsApp" className="w-5 h-5" />
+            WhatsApp
           </a>
         </div>
       </div>

--- a/src/components/Servicios.jsx
+++ b/src/components/Servicios.jsx
@@ -2,16 +2,28 @@
 import { useRef } from "react";
 import ServicioCard from "./ServicioCard";
 import TitleWithClouds from "./TitleWithClouds";
-import { FaStethoscope, FaSyringe, FaIdBadge, FaPassport, FaFlask, FaDog, FaAmbulance } from "react-icons/fa";
+import {
+  FaStethoscope,
+  FaBone,
+  FaBrain,
+  FaIdBadge,
+  FaSyringe,
+  FaFlask,
+  FaXRay,
+  FaPassport,
+  FaDog,
+} from "react-icons/fa";
 
 const servicios = [
-  { titulo: "Consultas a Domicilio", descripcion: "…", icono: <FaStethoscope /> },
-  { titulo: "Vacunación y Desparasitación", descripcion: "…", icono: <FaSyringe /> },
-  { titulo: "Identificación de Animales", descripcion: "…", icono: <FaIdBadge /> },
-  { titulo: "Certificados de Salud y Viaje", descripcion: "…", icono: <FaPassport /> },
-  { titulo: "Revisiones y Análisis Clínicos", descripcion: "…", icono: <FaFlask /> },
-  { titulo: "Atención Geriátrica", descripcion: "…", icono: <FaDog /> },
-  { titulo: "Servicio de Urgencia", descripcion: "…", icono: <FaAmbulance /> },
+  { titulo: "Medicina general", icono: <FaStethoscope /> },
+  { titulo: "Traumatología", icono: <FaBone /> },
+  { titulo: "Neurología", icono: <FaBrain /> },
+  { titulo: "Identificación de animales", icono: <FaIdBadge /> },
+  { titulo: "Vacunación y desparasitación", icono: <FaSyringe /> },
+  { titulo: "Análisis clínicos", icono: <FaFlask /> },
+  { titulo: "Diagnóstico por imagen (Radiografía y ecografía)", icono: <FaXRay /> },
+  { titulo: "Certificados de salud y de viaje", icono: <FaPassport /> },
+  { titulo: "Atención geriátrica", icono: <FaDog /> },
 ];
 
 export default function Servicios() {
@@ -70,29 +82,11 @@ export default function Servicios() {
         </button>
       </div>
 
-      {/* DESKTOP: grillas 4 + 3 */}
-      <div className="hidden md:block px-4">
-        {/* Fila superior: 4 columnas fijas */}
-        <div
-          className="grid gap-8 mx-auto justify-center"
-          style={{ gridTemplateColumns: "repeat(4, 300px)" }}
-        >
-          {servicios.slice(0, 4).map((s) => (
-            <ServicioCard key={s.titulo} {...s} />
-          ))}
-        </div>
-
-        {/* Fila inferior: 3 columnas centradas */}
-        <div className="mt-8 flex justify-center">
-          <div
-            className="grid gap-8"
-            style={{ gridTemplateColumns: "repeat(3, 300px)" }}
-          >
-            {servicios.slice(4).map((s) => (
-              <ServicioCard key={s.titulo} {...s} />
-            ))}
-          </div>
-        </div>
+      {/* DESKTOP: grilla 3 x 3 */}
+      <div className="hidden md:grid grid-cols-3 gap-8 justify-center px-4">
+        {servicios.map((s) => (
+          <ServicioCard key={s.titulo} {...s} />
+        ))}
       </div>
     </section>
   );

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { FaSun, FaMoon } from "react-icons/fa";
 import logo from "../assets/logo.png";
 
 export default function Header({ spaceMode, toggleSpaceMode }) {
@@ -25,10 +26,11 @@ export default function Header({ spaceMode, toggleSpaceMode }) {
           <img src="src/assets/icons8-instagram.svg" alt="Instagram" className="w-8 h-10" />
         </a>
         <button
-          onClick={toggleSpaceMode} 
-          className="bg-[#5c7c4d] text-white px-4 py-2 rounded-lg text-center"
+          onClick={toggleSpaceMode}
+          aria-label={spaceMode ? 'Modo Claro' : 'Modo Espacial'}
+          className="bg-[#5c7c4d] text-white rounded-lg w-10 h-10 grid place-items-center"
         >
-          {spaceMode ? 'Modo Claro' : 'Modo Espacial'}
+          {spaceMode ? <FaSun /> : <FaMoon />}
         </button>
         <a href="#reserva" className="bg-[#5c7c4d] text-white px-4 py-2 rounded-lg text-center">
           Reservar tu hora
@@ -78,9 +80,10 @@ export default function Header({ spaceMode, toggleSpaceMode }) {
           </div>
           <button
             onClick={() => { toggleSpaceMode(); setOpen(false); }}
-            className="bg-[#5c7c4d] text-white px-4 py-2 rounded-lg"
+            aria-label={spaceMode ? 'Modo Claro' : 'Modo Espacial'}
+            className="bg-[#5c7c4d] text-white rounded-lg w-10 h-10 grid place-items-center"
           >
-            {spaceMode ? 'Modo Claro' : 'Modo Espacial'}
+            {spaceMode ? <FaSun /> : <FaMoon />}
           </button>
           <a
             href="#reserva"


### PR DESCRIPTION
## Summary
- replace theme toggle text with fixed-size icons to avoid navbar jump
- add nine service cards and desktop grid layout
- remove service descriptions, add booking & WhatsApp actions
- wire up reservation form to EmailJS API
- document required EmailJS variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b26d0de628832fa7bbf88fe604c03c