### PR TITLE
feat: expand services and integrate booking

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
   </head>
   <body>
     <div id="root"></div>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@emailjs/browser@4/dist/email.min.js"></script>
+    <script type="text/javascript">
+      // TODO: reemplazar "PUBLIC_KEY" con la clave pública de EmailJS
+      emailjs.init('PUBLIC_KEY');
+    </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/src/components/Formularioreseva.jsx
+++ b/src/components/Formularioreseva.jsx
@@ -1,10 +1,28 @@
 // src/components/FormularioReserva.jsx
+import { useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import TitleWithClouds from './TitleWithClouds';
 
 export default function FormularioReserva() {
   const [searchParams] = useSearchParams();
   const asunto = searchParams.get('asunto') || '';
+  const formRef = useRef(null);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const form = formRef.current;
+    if (!window.emailjs) return;
+    window.emailjs
+      .sendForm('SERVICE_ID', 'TEMPLATE_ID', form)
+      .then(() => {
+        // TODO: revisar conflictos de horario antes de crear eventos en Google Calendar
+        form.reset();
+        alert('Solicitud enviada');
+      })
+      .catch((err) => {
+        console.error('EmailJS error', err);
+      });
+  };
 
   return (
     <section
@@ -17,7 +35,7 @@ export default function FormularioReserva() {
         </TitleWithClouds>
       </div>
 
-      <form className="bg-white dark:bg-neutral-800 dark:text-white p-8 rounded-xl shadow-md w-full max-w-md space-y-4">
+      <form ref={formRef} onSubmit={handleSubmit} className="bg-white dark:bg-neutral-800 dark:text-white p-8 rounded-xl shadow-md w-full max-w-md space-y-4">
 
         {/* Fila 1: Especie / Edad */}
         <div className="grid grid-cols-2 gap-4">

--- a/src/components/ServicioCard.jsx
+++ b/src/components/ServicioCard.jsx
@@ -1,8 +1,9 @@
 // ServicioCard.jsx
 import { useState } from "react";
+import { FaWhatsapp } from "react-icons/fa";
 import useIsMobile from "../hooks/useIsMobile";
 
-export default function ServicioCard({ titulo, descripcion, icono, className="" }) {
+export default function ServicioCard({ titulo, icono, className="" }) {
   const [flipped, setFlipped] = useState(false);
   const isMobile = useIsMobile();
   const hover = (v)=>{ if (!isMobile) setFlipped(v); };
@@ -21,21 +22,34 @@ export default function ServicioCard({ titulo, descripcion, icono, className="" 
         </div>
 
         {/* Reverso */}
-        <div className="absolute inset-0 rounded-2xl shadow-[0_12px_28px_rgba(0,0,0,.18)] bg-[#C5E0D8] text-neutralDark [transform:rotateY(180deg)] [backface-visibility:hidden] p-5 flex flex-col items-center justify-center gap-3">
-          <p className="text-sm text-center">{descripcion}</p>
-          <button
-            onClick={() => {
-              const params = new URLSearchParams(window.location.search);
-              params.set('asunto', titulo);
-              const newUrl = `${window.location.pathname}?${params.toString()}#reserva`;
-              window.history.pushState(null, '', newUrl);
-              window.dispatchEvent(new PopStateEvent('popstate'));
-              document.getElementById('reserva')?.scrollIntoView({ behavior: 'smooth' });
-            }}
-            className="bg-[#41658A] text-white px-4 py-2 rounded-lg hover:opacity-90"
-          >
-            Reservar Hora
-          </button>
+        <div className="absolute inset-0 rounded-2xl shadow-[0_12px_28px_rgba(0,0,0,.18)] bg-[#C5E0D8] text-neutralDark [transform:rotateY(180deg)] [backface-visibility:hidden] p-5 flex flex-col items-center justify-center gap-4">
+          {icono ? <div className="text-5xl text-primary">{icono}</div> : null}
+          <div className="flex gap-3">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                const params = new URLSearchParams(window.location.search);
+                params.set('asunto', titulo);
+                const newUrl = `${window.location.pathname}?${params.toString()}#reserva`;
+                window.history.pushState(null, '', newUrl);
+                window.dispatchEvent(new PopStateEvent('popstate'));
+                document.getElementById('reserva')?.scrollIntoView({ behavior: 'smooth' });
+              }}
+              className="bg-[#41658A] text-white px-4 py-2 rounded-lg hover:opacity-90"
+            >
+              Reservar Hora
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                const message = encodeURIComponent(`Hola, estoy interesado en el servicio de ${titulo}.`);
+                window.open(`https://wa.me/34666666666?text=${message}`, '_blank');
+              }}
+              className="bg-[#25D366] text-white px-4 py-2 rounded-lg flex items-center gap-2 hover:opacity-90"
+            >
+              <FaWhatsapp />
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Servicios.jsx
+++ b/src/components/Servicios.jsx
@@ -2,16 +2,28 @@
 import { useRef } from "react";
 import ServicioCard from "./ServicioCard";
 import TitleWithClouds from "./TitleWithClouds";
-import { FaStethoscope, FaSyringe, FaIdBadge, FaPassport, FaFlask, FaDog, FaAmbulance } from "react-icons/fa";
+import {
+  FaStethoscope,
+  FaSyringe,
+  FaIdBadge,
+  FaPassport,
+  FaFlask,
+  FaDog,
+  FaBrain,
+  FaXRay,
+} from "react-icons/fa";
+import { GiBrokenBone } from "react-icons/gi";
 
 const servicios = [
-  { titulo: "Consultas a Domicilio", descripcion: "…", icono: <FaStethoscope /> },
-  { titulo: "Vacunación y Desparasitación", descripcion: "…", icono: <FaSyringe /> },
-  { titulo: "Identificación de Animales", descripcion: "…", icono: <FaIdBadge /> },
-  { titulo: "Certificados de Salud y Viaje", descripcion: "…", icono: <FaPassport /> },
-  { titulo: "Revisiones y Análisis Clínicos", descripcion: "…", icono: <FaFlask /> },
-  { titulo: "Atención Geriátrica", descripcion: "…", icono: <FaDog /> },
-  { titulo: "Servicio de Urgencia", descripcion: "…", icono: <FaAmbulance /> },
+  { titulo: "Medicina general", icono: <FaStethoscope /> },
+  { titulo: "Traumatología", icono: <GiBrokenBone /> },
+  { titulo: "Neurología", icono: <FaBrain /> },
+  { titulo: "Identificación de animales", icono: <FaIdBadge /> },
+  { titulo: "Vacunación y desparasitación", icono: <FaSyringe /> },
+  { titulo: "Análisis clínicos", icono: <FaFlask /> },
+  { titulo: "Diagnóstico por imagen (Radiografía y ecografía)", icono: <FaXRay /> },
+  { titulo: "Certificados de salud y de viaje", icono: <FaPassport /> },
+  { titulo: "Atención geriátrica", icono: <FaDog /> },
 ];
 
 export default function Servicios() {
@@ -70,28 +82,15 @@ export default function Servicios() {
         </button>
       </div>
 
-      {/* DESKTOP: grillas 4 + 3 */}
+      {/* DESKTOP: grilla 3x3 */}
       <div className="hidden md:block px-4">
-        {/* Fila superior: 4 columnas fijas */}
         <div
           className="grid gap-8 mx-auto justify-center"
-          style={{ gridTemplateColumns: "repeat(4, 300px)" }}
+          style={{ gridTemplateColumns: "repeat(3, 300px)" }}
         >
-          {servicios.slice(0, 4).map((s) => (
+          {servicios.map((s) => (
             <ServicioCard key={s.titulo} {...s} />
           ))}
-        </div>
-
-        {/* Fila inferior: 3 columnas centradas */}
-        <div className="mt-8 flex justify-center">
-          <div
-            className="grid gap-8"
-            style={{ gridTemplateColumns: "repeat(3, 300px)" }}
-          >
-            {servicios.slice(4).map((s) => (
-              <ServicioCard key={s.titulo} {...s} />
-            ))}
-          </div>
         </div>
       </div>
     </section>

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -49,8 +49,8 @@ export default function Header({ spaceMode, toggleSpaceMode }) {
             <img src={instagramIcon} alt="Instagram" className="block w-10 h-10" />
           </a>
         <button
-          onClick={toggleSpaceMode} 
-          className="bg-[#5c7c4d] text-white px-4 py-2 rounded-lg text-center"
+          onClick={toggleSpaceMode}
+          className="bg-[#5c7c4d] text-white px-4 py-2 rounded-lg text-center w-40"
         >
           {spaceMode ? 'Modo Claro' : 'Modo Espacial'}
         </button>
@@ -102,7 +102,7 @@ export default function Header({ spaceMode, toggleSpaceMode }) {
           </div>
           <button
             onClick={() => { toggleSpaceMode(); setOpen(false); }}
-            className="bg-[#5c7c4d] text-white px-4 py-2 rounded-lg"
+            className="bg-[#5c7c4d] text-white px-4 py-2 rounded-lg w-40 self-end"
           >
             {spaceMode ? 'Modo Claro' : 'Modo Espacial'}
           </button>


### PR DESCRIPTION
## Summary
- standardize navbar toggle width to avoid layout shifts
- expand services to nine items with new icons and grid layout
- add WhatsApp contact on service cards and prepare EmailJS booking form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b271c4e990832f83a311c3e248c957