### PR TITLE
feat: add bilingual support and service card hint

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,8 @@ import StarBackground from './components/StarBackground';
 export default function App() {
   const [spaceMode, setSpaceMode] = useState(false);
   const toggleSpaceMode = () => setSpaceMode(!spaceMode);
+  const [lang, setLang] = useState('es');
+  const toggleLang = () => setLang(lang === 'es' ? 'en' : 'es');
 
   return (
     <div id="page" className={spaceMode ? 'dark' : ''}>
@@ -17,7 +19,7 @@ export default function App() {
         <Routes>
           <Route
             path="/jetvet"
-            element={<Home spaceMode={spaceMode} toggleSpaceMode={toggleSpaceMode} />}
+            element={<Home spaceMode={spaceMode} toggleSpaceMode={toggleSpaceMode} lang={lang} toggleLang={toggleLang} />}
           />
         </Routes>
       </div>

--- a/src/components/Formularioreseva.jsx
+++ b/src/components/Formularioreseva.jsx
@@ -2,8 +2,9 @@
 import { useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import TitleWithClouds from './TitleWithClouds';
+import { texts } from '../translations';
 
-export default function FormularioReserva() {
+export default function FormularioReserva({ lang }) {
   const [searchParams] = useSearchParams();
   const asunto = searchParams.get('asunto') || '';
   const formRef = useRef(null);
@@ -31,7 +32,7 @@ export default function FormularioReserva() {
     >
       <div className="mb-8">
         <TitleWithClouds as="h1" className="text-4xl volkhov-bold text-center dark:text-white">
-          RESERVA TU HORA
+          {texts[lang].form.title}
         </TitleWithClouds>
       </div>
 
@@ -40,7 +41,7 @@ export default function FormularioReserva() {
         {/* Fila 1: Especie / Edad */}
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-semibold mb-1">Especie</label>
+            <label className="block text-sm font-semibold mb-1">{texts[lang].form.species}</label>
             <input
               type="text"
               name="especie"
@@ -48,7 +49,7 @@ export default function FormularioReserva() {
             />
           </div>
           <div>
-            <label className="block text-sm font-semibold mb-1">Edad</label>
+            <label className="block text-sm font-semibold mb-1">{texts[lang].form.age}</label>
             <input
               type="text"
               name="edad"
@@ -60,7 +61,7 @@ export default function FormularioReserva() {
         {/* Fila 2: Castrado / Raza */}
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-semibold mb-1">Castrado</label>
+            <label className="block text-sm font-semibold mb-1">{texts[lang].form.neutered}</label>
             <input
               type="text"
               name="castrado"
@@ -68,7 +69,7 @@ export default function FormularioReserva() {
             />
           </div>
           <div>
-            <label className="block text-sm font-semibold mb-1">Raza</label>
+            <label className="block text-sm font-semibold mb-1">{texts[lang].form.breed}</label>
             <input
               type="text"
               name="raza"
@@ -79,7 +80,7 @@ export default function FormularioReserva() {
 
         {/* Motivo de consulta (desde URL) */}
         <div>
-          <label className="block text-sm font-semibold mb-1">Motivo de Consulta</label>
+          <label className="block text-sm font-semibold mb-1">{texts[lang].form.reason}</label>
           <input
             type="text"
             name="asunto"
@@ -91,7 +92,7 @@ export default function FormularioReserva() {
 
         {/* Tutor */}
         <div>
-          <label className="block text-sm font-semibold mb-1">Nombre compañero/tutor</label>
+          <label className="block text-sm font-semibold mb-1">{texts[lang].form.tutor}</label>
           <input
             type="text"
             name="tutor"
@@ -101,7 +102,7 @@ export default function FormularioReserva() {
 
         {/* Mensaje */}
         <div>
-          <label className="block text-sm font-semibold mb-1">Mensaje</label>
+          <label className="block text-sm font-semibold mb-1">{texts[lang].form.message}</label>
           <textarea
             name="mensaje"
             className="w-full border rounded px-3 py-2 h-24 dark:bg-neutral-700"
@@ -112,7 +113,7 @@ export default function FormularioReserva() {
           type="submit"
           className="bg-primary text-white px-6 py-2 rounded hover:bg-[#5c7c4d]"
         >
-          Reservar Hora
+          {texts[lang].form.submit}
         </button>
       </form>
     </section>

--- a/src/components/ServicioCard.jsx
+++ b/src/components/ServicioCard.jsx
@@ -1,17 +1,25 @@
 // ServicioCard.jsx
-import { useState } from "react";
-import { FaWhatsapp } from "react-icons/fa";
+import { useState, useEffect } from "react";
+import { FaWhatsapp, FaRegHandPointer } from "react-icons/fa";
 import useIsMobile from "../hooks/useIsMobile";
+import { texts } from "../translations";
 
-export default function ServicioCard({ titulo, icono, className="" }) {
+export default function ServicioCard({ titulo, icono, className="", lang, showHint=false }) {
   const [flipped, setFlipped] = useState(false);
   const isMobile = useIsMobile();
   const hover = (v)=>{ if (!isMobile) setFlipped(v); };
+  const [hint, setHint] = useState(showHint);
+  useEffect(() => {
+    if (!showHint) return;
+    const timer = setTimeout(() => setHint(false), 4000);
+    return () => clearTimeout(timer);
+  }, [showHint]);
+  const t = texts[lang].serviceCard;
 
   return (
     <div
       className={`relative w-full h-[440px] md:h-[233px] cursor-pointer [perspective:1000px] ${className}`}
-      onClick={()=> isMobile && setFlipped(!flipped)}
+      onClick={()=> { if (isMobile) { setFlipped(!flipped); setHint(false); } }}
       onMouseEnter={()=>hover(true)} onMouseLeave={()=>hover(false)}
     >
       <div className={`w-full h-full transition-transform duration-500 [transform-style:preserve-3d] ${flipped ? "[transform:rotateY(180deg)]" : ""}`}>
@@ -19,6 +27,9 @@ export default function ServicioCard({ titulo, icono, className="" }) {
         <div className="absolute inset-0 rounded-2xl shadow-[0_12px_28px_rgba(0,0,0,.18)] bg-[#4E6B3B] text-white [backface-visibility:hidden] p-6 flex flex-col items-center justify-center gap-4">
           {icono ? <div className="text-5xl">{icono}</div> : null}
           <h3 className="text-xl font-semibold text-center leading-snug">{titulo}</h3>
+          {hint && isMobile && (
+            <FaRegHandPointer className="absolute bottom-4 right-4 text-3xl animate-bounce" />
+          )}
         </div>
 
         {/* Reverso */}
@@ -37,12 +48,12 @@ export default function ServicioCard({ titulo, icono, className="" }) {
               }}
               className="bg-[#41658A] text-white px-4 py-2 rounded-lg hover:opacity-90"
             >
-              Reservar Hora
+              {t.book}
             </button>
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                const message = encodeURIComponent(`Hola, estoy interesado en el servicio de ${titulo}.`);
+                const message = encodeURIComponent(t.whatsapp.replace('{servicio}', titulo));
                 window.open(`https://wa.me/34666666666?text=${message}`, '_blank');
               }}
               className="bg-[#25D366] text-white px-4 py-2 rounded-lg flex items-center gap-2 hover:opacity-90"

--- a/src/components/Servicios.jsx
+++ b/src/components/Servicios.jsx
@@ -9,24 +9,24 @@ import {
   FaPassport,
   FaFlask,
   FaDog,
-  FaBrain,
   FaXRay,
 } from "react-icons/fa";
-import { GiBrokenBone } from "react-icons/gi";
+import { GiBrokenBone, GiScalpel } from "react-icons/gi";
+import { texts } from "../translations";
 
 const servicios = [
-  { titulo: "Medicina general", icono: <FaStethoscope /> },
-  { titulo: "Traumatología", icono: <GiBrokenBone /> },
-  { titulo: "Neurología", icono: <FaBrain /> },
-  { titulo: "Identificación de animales", icono: <FaIdBadge /> },
-  { titulo: "Vacunación y desparasitación", icono: <FaSyringe /> },
-  { titulo: "Análisis clínicos", icono: <FaFlask /> },
-  { titulo: "Diagnóstico por imagen (Radiografía y ecografía)", icono: <FaXRay /> },
-  { titulo: "Certificados de salud y de viaje", icono: <FaPassport /> },
-  { titulo: "Atención geriátrica", icono: <FaDog /> },
+  { key: "general_medicine", icono: <FaStethoscope /> },
+  { key: "vaccination", icono: <FaSyringe /> },
+  { key: "animal_id", icono: <FaIdBadge /> },
+  { key: "blood_analyses", icono: <FaFlask /> },
+  { key: "health_travel_certificates", icono: <FaPassport /> },
+  { key: "geriatric_care", icono: <FaDog /> },
+  { key: "diagnostic_imaging", icono: <FaXRay /> },
+  { key: "surgery", icono: <GiScalpel /> },
+  { key: "traumatology", icono: <GiBrokenBone /> },
 ];
 
-export default function Servicios() {
+export default function Servicios({ lang }) {
   const trackRef = useRef(null);
   const scroll = (dir) => {
     const el = trackRef.current;
@@ -45,7 +45,7 @@ export default function Servicios() {
           as="h2"
           className="text-3xl lg:text-5xl volkhov-bold text-neutralDark/85 dark:text-white"
         >
-          Nuestros Servicios
+          {texts[lang].services.title}
         </TitleWithClouds>
       </div>
 
@@ -56,10 +56,13 @@ export default function Servicios() {
           className="flex items-center gap-4 overflow-x-auto snap-x snap-mandatory px-4
                      scroll-pl-4 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         >
-          {servicios.map((s) => (
+          {servicios.map((s, i) => (
             <ServicioCard
-              key={s.titulo}
-              {...s}
+              key={s.key}
+              titulo={texts[lang].services.items[s.key]}
+              icono={s.icono}
+              lang={lang}
+              showHint={i === 0}
               className="shrink-0 snap-center w-[min(94vw,560px)] mx-auto"
             />
           ))}
@@ -88,8 +91,8 @@ export default function Servicios() {
           className="grid gap-8 mx-auto justify-center"
           style={{ gridTemplateColumns: "repeat(3, 300px)" }}
         >
-          {servicios.map((s) => (
-            <ServicioCard key={s.titulo} {...s} />
+          {servicios.map((s, i) => (
+            <ServicioCard key={s.key} titulo={texts[lang].services.items[s.key]} icono={s.icono} lang={lang} showHint={i === 0} />
           ))}
         </div>
       </div>

--- a/src/components/SobreNosotros.jsx
+++ b/src/components/SobreNosotros.jsx
@@ -1,7 +1,9 @@
 import about_img from '../assets/JetVetIlustracion02_WIP2_500px.png';
 import TitleWithClouds from './TitleWithClouds';
+import { texts } from '../translations';
 
-export default function SobreNosotros() {
+export default function SobreNosotros({ lang }) {
+  const t = texts[lang].about;
   return (
     <section
       id="nosotros"
@@ -22,26 +24,9 @@ export default function SobreNosotros() {
   {/* Texto: en mobile arriba (order-1), en desktop a la derecha (lg:order-2) */}
   <div className="order-1 lg:order-2 max-w-3xl mx-auto lg:mx-0 text-center lg:text-right">
 
-    <TitleWithClouds as="h2" className="text-3xl lg:text-5xl volkhov-bold mb-5 dark:text-white">Sobre Nosotros</TitleWithClouds>
+    <TitleWithClouds as="h2" className="text-3xl lg:text-5xl volkhov-bold mb-5 dark:text-white">{t.title}</TitleWithClouds>
 
-    <p className="text-[14px] lg:text-xl volkhov-regular">
-  Somos un equipo con experiencia en <b>clínica veterinaria</b> y <b>hospitales de referencia</b>, 
-  siempre en <b>formación continua</b> para ofrecer la <b>atención de calidad</b> que vuestros 
-  compañeros de cuatro patas se merecen. 
-  <br /><br />
-  
-  Entendemos que tu peludo es parte de la <b>familia</b>; por ello, llevamos nuestra atención 
-  con <b>cariño</b> y <b>profesionalidad</b> a su rincón favorito: <b>vuestro hogar</b>.
-  <br /><br />
-  
-  Despídete del <b>estrés</b> del transportín, los <b>viajes</b> y las <b>salas de espera</b>. 
-  Nosotros nos adaptamos y <b>aterrizamos en vuestra puerta</b>.
-  <br /><br />
-  
-  Disponemos de <b>servicio de laboratorio propio</b>, <b>diagnóstico por imagen</b> y 
-  <b>hospitalización</b> en nuestros <b>centros asociados</b>. Para que a tu peludo no le falte de nada.
-  <br /><br />
-</p>
+    <p className="text-[14px] lg:text-xl volkhov-regular">{t.body}</p>
   </div>
 </div>
     </section>

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -1,8 +1,10 @@
 // src/components/Footer.jsx
-export default function Footer() {
+import { texts } from '../translations';
+
+export default function Footer({ lang }) {
   return (
     <footer className="bg-[#B6BE9C]/70 md:bg-[#B6BE9C] dark:bg-transparent text-gray dark:text-white text-center g-full pt-10 py-8 text-sm">
-      <p>© 2025 Jet Vets. Todos los derechos reservados.</p>
+      <p>{texts[lang].footer.rights}</p>
     </footer>
   );
 }

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -2,8 +2,9 @@ import { useEffect, useState } from "react";
 import logo from "../assets/logo.png";
 import whatsappIcon from "../assets/icons8-whatsapp.svg";
 import instagramIcon from "../assets/icons8-instagram.svg";
+import { texts } from "../translations";
 
-export default function Header({ spaceMode, toggleSpaceMode }) {
+export default function Header({ spaceMode, toggleSpaceMode, lang, toggleLang }) {
   const [open, setOpen] = useState(false);
 
   // Bloquea scroll del body cuando el menú está abierto (mejor UX)
@@ -21,26 +22,26 @@ export default function Header({ spaceMode, toggleSpaceMode }) {
         <a
   href="#nosotros"
   onClick={(e) => {
-    e.preventDefault(); // evita el salto brusco por defecto
+    e.preventDefault();
     document.getElementById("nosotros")?.scrollIntoView({
       behavior: "smooth",
     });
   }}
   className="text-primary dark:text-white font-medium cursor-pointer"
 >
-  Sobre Nosotros
+  {texts[lang].header.about}
 </a>
         <a
   href="#servicios"
   onClick={(e) => {
-    e.preventDefault(); // evita el salto brusco por defecto
-    document.getElementById("servicios")?.scrollIntoView({ 
+    e.preventDefault();
+    document.getElementById("servicios")?.scrollIntoView({
       behavior: "smooth",
     });
   }}
   className="text-primary dark:text-white font-medium cursor-pointer"
 >
-  Servicios 
+  {texts[lang].header.services}
 </a>
           <a href="https://wa.me/34666666666" target="_blank" rel="noopener noreferrer">
             <img src={whatsappIcon} alt="WhatsApp" className="block w-10 h-10" />
@@ -52,10 +53,16 @@ export default function Header({ spaceMode, toggleSpaceMode }) {
           onClick={toggleSpaceMode}
           className="bg-[#5c7c4d] text-white px-4 py-2 rounded-lg text-center w-40"
         >
-          {spaceMode ? 'Modo Claro' : 'Modo Espacial'}
+          {spaceMode ? texts[lang].header.light : texts[lang].header.space}
+        </button>
+        <button
+          onClick={toggleLang}
+          className="bg-[#5c7c4d] text-white px-4 py-2 rounded-lg text-center"
+        >
+          {lang === 'es' ? 'EN' : 'ES'}
         </button>
         <a href="#reserva" className="bg-[#5c7c4d] text-white px-4 py-2 rounded-lg text-center">
-          Reservar tu hora
+          {texts[lang].header.book}
         </a>
       </nav>
 
@@ -90,8 +97,8 @@ export default function Header({ spaceMode, toggleSpaceMode }) {
       >
         <nav className="flex flex-col items-end gap-6">
           <img src={logo} alt="Jet Vets Logo" className="h-[100px] md:h-[130px] mb-2"/>
-          <a href="#nosotros" className="text-primary dark:text-white font-medium" onClick={() => setOpen(false)}>Sobre Nosotros</a>
-          <a href="#servicios" className="text-primary dark:text-white font-medium" onClick={() => setOpen(false)}>Servicios</a>
+          <a href="#nosotros" className="text-primary dark:text-white font-medium" onClick={() => setOpen(false)}>{texts[lang].header.about}</a>
+          <a href="#servicios" className="text-primary dark:text-white font-medium" onClick={() => setOpen(false)}>{texts[lang].header.services}</a>
           <div className="flex items-center gap-4">
             <a href="https://wa.me/34666666666" target="_blank" rel="noopener noreferrer" onClick={() => setOpen(false)}>
               <img src={whatsappIcon} alt="WhatsApp" className="w-9 h-9" />
@@ -104,14 +111,20 @@ export default function Header({ spaceMode, toggleSpaceMode }) {
             onClick={() => { toggleSpaceMode(); setOpen(false); }}
             className="bg-[#5c7c4d] text-white px-4 py-2 rounded-lg w-40 self-end"
           >
-            {spaceMode ? 'Modo Claro' : 'Modo Espacial'}
+            {spaceMode ? texts[lang].header.light : texts[lang].header.space}
+          </button>
+          <button
+            onClick={() => { toggleLang(); setOpen(false); }}
+            className="bg-[#5c7c4d] text-white px-4 py-2 rounded-lg w-20 self-end"
+          >
+            {lang === 'es' ? 'EN' : 'ES'}
           </button>
           <a
             href="#reserva"
             onClick={() => setOpen(false)}
             className="mt-3 bg-[#5c7c4d] text-white px-1 py-3 rounded-lg"
           >
-            Reservar tu hora
+            {texts[lang].header.book}
           </a>
         </nav>
       </div>

--- a/src/components/hero.jsx
+++ b/src/components/hero.jsx
@@ -1,8 +1,10 @@
 // src/components/Hero.jsx
 import mascotas from '../assets/Ilustracion2_Clean_500.png';
 import FloatingRocket from './FloatingRocket';
+import { texts } from '../translations';
 
-export default function Hero() {
+export default function Hero({ lang }) {
+  const t = texts[lang].hero;
   return (
     <section className="relative isolate bg-[#B6BE9C] dark:bg-transparent w-full min-h-screen flex items-center overflow-x-clip">
       {/* Cohete animado (al fondo) */}
@@ -15,11 +17,10 @@ export default function Hero() {
         <div className="flex flex-col justify-center items-center md:items-end text-center md:text-right gap-2 md:gap-10">
           <h1 className="volkhov-bold text-[30px] lg:text-[50px] text-neutralDark dark:text-white leading-[1.2] tracking-tight">
             Jet Vets <br />
-            <span className="text-primary">Servicios veterinarios de otra galaxia </span><br />
-            directa a tu hogar. 
+            <span className="text-primary">{t.subtitle}</span>
           </h1>
           <p className="volkhov-bold text-[16px] lg:text-[30px] text-neutralDark dark:text-white leading-tight">
-            ¡Jet Vets surge con el proposito de acercar un servicio veterinario de calidad a cualquier rincon del planeta!
+            {t.description}
           </p>
 {/*         <p className="volkhov-bold text-[20px] lg:text-[16px] text-neutralDark dark:text-white leading-tight">
 Entendemos que tu peludo es parte de la familia, por ello llevamos nuestra antención con cariño y profesionalidad a su rincon favorito. Vuestro hogar. 

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -6,16 +6,16 @@ import Servicios from '../components/Servicios';
 import FormularioReserva from '../components/Formularioreseva';
 /* import LandingRocket from '../components/LandingRocket'; */
 
-export default function Home({ spaceMode, toggleSpaceMode }) {
+export default function Home({ spaceMode, toggleSpaceMode, lang, toggleLang }) {
   return (
     <>
-      <Header spaceMode={spaceMode} toggleSpaceMode={toggleSpaceMode} />
-      <Hero />
-      <Servicios />
-      <SobreNosotros />
-      <FormularioReserva />
+      <Header spaceMode={spaceMode} toggleSpaceMode={toggleSpaceMode} lang={lang} toggleLang={toggleLang} />
+      <Hero lang={lang} />
+      <Servicios lang={lang} />
+      <SobreNosotros lang={lang} />
+      <FormularioReserva lang={lang} />
       {/* <LandingRocket /> */}
-      <Footer />
+      <Footer lang={lang} />
     </>
   );
 }

--- a/src/translations.js
+++ b/src/translations.js
@@ -1,0 +1,103 @@
+export const texts = {
+  es: {
+    header: {
+      about: 'Sobre Nosotros',
+      services: 'Servicios',
+      book: 'Reserva tu cita',
+      space: 'Modo Espacial',
+      light: 'Modo Claro'
+    },
+    hero: {
+      subtitle: 'Servicios veterinarios de otra galaxia directos a tu hogar.',
+      description: '\u00a1Jet Vets surge con el propósito de acercar un servicio veterinario de calidad a cualquier rincón del planeta!'
+    },
+    about: {
+      title: 'Sobre Nosotros',
+      body: 'Somos un equipo con experiencia en clínica veterinaria y hospitales de referencia, siempre en formación continua para ofrecer la atención de calidad que vuestros compañeros de cuatro patas se merecen. Entendemos que tu peludo es parte de la familia; por ello, llevamos nuestra atención con cariño y profesionalidad a su rincón favorito: vuestro hogar. Despídete del estrés del transportín, los viajes y las salas de espera. Nosotros nos adaptamos y aterrizamos en vuestra puerta. Disponemos de servicio de laboratorio propio, diagnóstico por imagen y hospitalización en nuestros centros asociados. Para que a tu peludo no le falte de nada.'
+    },
+    services: {
+      title: 'Nuestros Servicios',
+      items: {
+        general_medicine: 'Medicina general',
+        vaccination: 'Vacunación y desparasitación',
+        animal_id: 'Identificación animal',
+        blood_analyses: 'Análisis clínicos',
+        health_travel_certificates: 'Certificados de salud y de viaje',
+        geriatric_care: 'Atención geriátrica',
+        diagnostic_imaging: 'Diagnóstico por imagen (Radiografía y ecografía)',
+        surgery: 'Cirugía',
+        traumatology: 'Traumatología'
+      }
+    },
+    serviceCard: {
+      book: 'Reservar cita',
+      whatsapp: 'Hola, estoy interesado en el servicio de {servicio}.'
+    },
+    form: {
+      title: 'RESERVA TU CITA',
+      species: 'Especie',
+      age: 'Edad',
+      neutered: 'Castrado',
+      breed: 'Raza',
+      reason: 'Motivo de la consulta',
+      tutor: 'Nombre compi/tutor',
+      message: 'Mensaje',
+      submit: 'Reservar Cita'
+    },
+    footer: {
+      rights: '\u00a9 2025 Jet Vets. Todos los derechos reservados.'
+    }
+  },
+  en: {
+    header: {
+      about: 'About Us',
+      services: 'Services',
+      book: 'Book your appointment',
+      space: 'Space Mode',
+      light: 'Light Mode'
+    },
+    hero: {
+      subtitle: 'Veterinary services from another galaxy, straight to your home.',
+      description: 'Jet Vets was created with the purpose of bringing high-quality veterinary care to every corner of the planet!'
+    },
+    about: {
+      title: 'Who we are',
+      body: 'We are a team with experience in veterinary clinics and referral hospitals, always pursuing continuous training to provide the quality care your four-legged companions deserve. We have our own laboratory services, diagnostic imaging, and hospitalization through our partner centers so your pet never goes without what they need.'
+    },
+    services: {
+      title: 'Our Services',
+      items: {
+        general_medicine: 'General medicine',
+        vaccination: 'Vaccination and deworming',
+        animal_id: 'Animal identification',
+        blood_analyses: 'Blood analyses',
+        health_travel_certificates: 'Health and travel certificates',
+        geriatric_care: 'Geriatric care',
+        diagnostic_imaging: 'Diagnostic imaging (X-ray and ultrasound)',
+        surgery: 'Surgery',
+        traumatology: 'Traumatology'
+      }
+    },
+    serviceCard: {
+      book: 'Book appointment',
+      whatsapp: 'Hi, I am interested in the {servicio} service.'
+    },
+    form: {
+      title: 'BOOK YOUR APPOINTMENT',
+      species: 'Species',
+      age: 'Age',
+      neutered: 'Neutered',
+      breed: 'Breed',
+      reason: 'Reason for visit',
+      tutor: 'Owner/guardian name',
+      message: 'Message',
+      submit: 'Book Appointment'
+    },
+    footer: {
+      rights: '\u00a9 2025 Jet Vets. All rights reserved.'
+    }
+  }
+};
+
+export default texts;
+


### PR DESCRIPTION
## Summary
- add translation table and language toggle for English/Spanish modes
- update copy to "Servicios veterinarios de otra galaxia directos a tu hogar" and "Reserva tu cita"
- add tap hint animation to service cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6376bb228832f99545f17e3a5ddaa