### PR TITLE
Open Google Calendar for appointment requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_JETVETS_CALENDAR_INVITEE_EMAIL="contacto@jetvets.com"

--- a/src/translations.js
+++ b/src/translations.js
@@ -45,6 +45,15 @@ export const texts = {
       ],
       breed: 'Raza',
       reason: 'Motivo de la consulta',
+      preferredDate: 'Fecha preferida',
+      preferredTimeBlock: 'Bloque horario preferido',
+      timeBlockPlaceholder: 'Selecciona un bloque…',
+      timeBlockOptions: [
+        '09:00 - 11:00',
+        '11:00 - 13:00',
+        '15:00 - 17:00',
+        '17:00 - 19:00'
+      ],
       reasonOptions: [
         { value: 'general_medicine', label: 'Medicina general' },
         { value: 'vaccination', label: 'Vacunación y desparasitación' },
@@ -64,7 +73,13 @@ export const texts = {
       phone: 'Teléfono',
       email: 'Correo electrónico',
       message: 'Mensaje',
-      submit: 'Reservar Cita'
+      submit: 'Reservar Cita',
+      disclaimer: '*La solicitud de cita no constituye confirmación automática. Confirmaremos disponibilidad a la brevedad.*',
+      calendarSuccess: 'Se abrió Google Calendar para crear la solicitud. Esta solicitud no confirma la cita. Nuestro equipo revisará la disponibilidad y confirmará por WhatsApp o correo.',
+      serviceRequired: 'Selecciona un servicio',
+      dateRequired: 'Selecciona una fecha preferida',
+      timeBlockRequired: 'Selecciona un bloque horario',
+      contactRequired: 'Indica teléfono o correo'
     },
     footer: {
       rights: '\u00a9 2025 Jet Vets. Todos los derechos reservados.'
@@ -116,6 +131,15 @@ export const texts = {
       ],
       breed: 'Breed',
       reason: 'Reason for visit',
+      preferredDate: 'Preferred date',
+      preferredTimeBlock: 'Preferred time block',
+      timeBlockPlaceholder: 'Select a time block…',
+      timeBlockOptions: [
+        '09:00 - 11:00',
+        '11:00 - 13:00',
+        '15:00 - 17:00',
+        '17:00 - 19:00'
+      ],
       reasonOptions: [
         { value: 'general_medicine', label: 'General medicine' },
         { value: 'vaccination', label: 'Vaccination and deworming' },
@@ -135,7 +159,13 @@ export const texts = {
       phone: 'Phone number',
       email: 'Email',
       message: 'Message',
-      submit: 'Book Appointment'
+      submit: 'Book Appointment',
+      disclaimer: '*Appointment requests do not confirm a booking automatically. We will confirm availability shortly.*',
+      calendarSuccess: 'Google Calendar opened to create the request. This request does not confirm the appointment. Our team will check availability and confirm via WhatsApp or email.',
+      serviceRequired: 'Select a service',
+      dateRequired: 'Select a preferred date',
+      timeBlockRequired: 'Select a time block',
+      contactRequired: 'Provide a phone number or email'
     },
     footer: {
       rights: '\u00a9 2025 Jet Vets. All rights reserved.'
@@ -144,4 +174,3 @@ export const texts = {
 };
 
 export default texts;
-


### PR DESCRIPTION
### Motivation
- Prevent automatic confirmation of bookings and instead open a pre-filled Google Calendar event so the team can confirm manually.
- Keep the existing reservation form fields and add minimal scheduling inputs (date + time block) for an MVP workflow without a backend.
- Use a client-side utility to build a `action=TEMPLATE` Google Calendar URL so the browser opens a draft event for the team to edit/confirm.
- Allow optionally inviting the business email from `.env` using `VITE_JETVETS_CALENDAR_INVITEE_EMAIL`.

### Description
- Replaced EmailJS submission flow in `src/components/Formularioreseva.jsx` with helpers: `buildGoogleCalendarUrl`, `formatDateToGoogleCalendar`, and `sanitizeText` to build a safe Calendar template link.
- Added form fields `preferred_date` (datepicker) and `preferred_block` (time block select) plus logic to compute a 60-minute suggested event inside the chosen block and validation for required fields and contact info.
- On submit the form now validates required fields, constructs the event `details` string with all form values, opens the calendar draft with `window.open(calendarUrl, "_blank", "noopener,noreferrer")`, and shows a success message and disclaimer under the submit button.
- Updated `src/translations.js` with new strings and created `.env.example` containing `VITE_JETVETS_CALENDAR_INVITEE_EMAIL="contacto@jetvets.com"`.

### Testing
- Started the dev server with `npm run dev` and Vite reported the app ready at `http://localhost:4173/jetvet` (success).
- Ran a Playwright navigation script that loaded the page and produced a screenshot of the booking form (success).
- No new automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950a86c46d4832fbae2eeb93427bb62)